### PR TITLE
allow 'allow' pref without whitelist url (e10s fix)

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -130,6 +130,7 @@ var Spoofer = (function () {
 		var url = Preferences.getCharPref("whitelist");
 
 		if (!url) {
+			allows = new Allow(Preferences.getCharPref("allow"));
 			return;
 		}
 


### PR DESCRIPTION
If a user changes the 'allow' preference string - but doesn't have a 'whitelist' URL set - the 'allow' string is now correctly re-loaded into 'allows'.
Previously the user needed FF e10s multiprocess turned off to avoid this bug, or if e10s was on the user needed to re-start the browser every time they changed the 'allow' pref string.